### PR TITLE
Use ext4 volume instead of tmpfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ADD init.sh init.sh
 
 #specify the of memory that the uml kernel can use 
 ENV MEM 2G
+ENV DISK 2G
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "bash" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,10 @@
 #start sshd
 /etc/init.d/ssh start
 
+# Create the ext4 volume image
+dd if=/dev/zero of=/var/tmp/docker.img bs=1 count=0 seek=${DISK}
+mkfs.ext4 /var/tmp/docker.img
+
 #start the uml kernel with docker inside
 TMPDIR=/dev /sbin/start-stop-daemon --start --chuid `whoami` --chdir $PWD --background --make-pidfile --pidfile /tmp/kernel.pid --exec /linux/linux -- \
  rootfstype=hostfs rw quiet eth0=slirp,,/usr/bin/slirp-fullbolt mem=$MEM init=/init.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,11 @@
 #start sshd
 /etc/init.d/ssh start
 
-# Create the ext4 volume image
-dd if=/dev/zero of=/var/tmp/docker.img bs=1 count=0 seek=${DISK}
-mkfs.ext4 /var/tmp/docker.img
+# Create the ext4 volume image if DISK is set
+if [[ -n "${DISK}" ]] ; then
+    dd if=/dev/zero of=/var/tmp/docker.img bs=1 count=0 seek=${DISK}
+    mkfs.ext4 /var/tmp/docker.img
+fi
 
 #start the uml kernel with docker inside
 TMPDIR=/dev /sbin/start-stop-daemon --start --chuid `whoami` --chdir $PWD --background --make-pidfile --pidfile /tmp/kernel.pid --exec /linux/linux -- \

--- a/init.sh
+++ b/init.sh
@@ -7,7 +7,7 @@ mkdir /dev/pts
 mount -t devpts devpts /dev/pts
 rm /dev/ptmx
 ln -s /dev/pts/ptmx /dev/ptmx
-mkdir -p /var/lib/docker/; mount -t tmpfs none /var/lib/docker/
+mkdir -p /var/lib/docker/; mount -t ext4 /var/tmp/docker.img /var/lib/docker/
 
 ip link set dev lo up
 ip link set dev eth0 up

--- a/init.sh
+++ b/init.sh
@@ -7,7 +7,12 @@ mkdir /dev/pts
 mount -t devpts devpts /dev/pts
 rm /dev/ptmx
 ln -s /dev/pts/ptmx /dev/ptmx
-mkdir -p /var/lib/docker/; mount -t ext4 /var/tmp/docker.img /var/lib/docker/
+mkdir -p /var/lib/docker/
+if [[ -f /var/tmp/docker.img ]] ; then
+    mount -t ext4 /var/tmp/docker.img /var/lib/docker/
+else
+    mount -t tmpfs none /var/lib/docker/
+fi
 
 ip link set dev lo up
 ip link set dev eth0 up


### PR DESCRIPTION
tmpfs is untenable for bigger builds without allocating large amounts of
RAM to containers.

An ext4 volume however works with overlay2 and offers the container
operator multiple avenues to constrain disk usage separately from memory
usage.

The size of the ext4 volume is configurable via the `DISK` environment
variable, similarly to memory.


_Awesome app BTW, I'd just started spiking exactly this out to allow safe image builds in a Kubernetes cluster (because Docker in Docker is dangerous as f), glad I did a google and found this before getting to far into it myself 👍 ._