### PR TITLE
Default docker permissions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,20 @@ fi
 
 #start the uml kernel with docker inside
 echo "DIUID_DOCKERD_FLAGS=\"$DIUID_DOCKERD_FLAGS\"" > /tmp/env
+
+# Get docker group from DIUID_DOCKERD_FLAGS
+DIUID_DOCKERD_GROUP='docker'
+DIUID_DOCKERD_OPTS=`getopt -q -o G: --long group: -n 'getopt' -- $DIUID_DOCKERD_FLAGS`
+eval set -- "$DIUID_DOCKERD_OPTS"
+while true; do
+  case "$1" in
+	-G|--group ) DIUID_DOCKERD_GROUP="$2"; shift 2 ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+echo "DIUID_DOCKERD_GROUP=\"$DIUID_DOCKERD_GROUP\"" >> /tmp/env
+
 /sbin/start-stop-daemon --start --background --make-pidfile --pidfile /tmp/kernel.pid --exec /bin/bash -- -c "exec /kernel.sh > /tmp/kernel.log 2>&1"
 
 echo -n "waiting for dockerd "

--- a/init.sh
+++ b/init.sh
@@ -29,6 +29,8 @@ ssh -f -N -o StrictHostKeyChecking=no \
     -R0.0.0.0:2376:127.0.0.1:2376 \
     10.0.2.2
 
+chmod 0660 /var/run/docker.sock && chown root:docker /var/run/docker.sock
+
 PATH=/usr/bin:$PATH dockerd --userland-proxy-path=$(which diuid-docker-proxy) -H unix:///var/run/docker.sock $DIUID_DOCKERD_FLAGS
 
 ret=$?

--- a/init.sh
+++ b/init.sh
@@ -29,19 +29,8 @@ ssh -f -N -o StrictHostKeyChecking=no \
     -R0.0.0.0:2376:127.0.0.1:2376 \
     10.0.2.2
 
-# Change group for docker.sock across DIUID_DOCKERD_FLAGS
-docker_group='docker'
-DIUID_DOCKERD_OPTS=`getopt -q -o G: --long group: -n 'getopt' -- $DIUID_DOCKERD_FLAGS`
-eval set -- "$DIUID_DOCKERD_OPTS"
-while true; do
-  case "$1" in
-	-G|--group ) docker_group="$2"; shift 2 ;;
-    -- ) shift; break ;;
-    * ) break ;;
-  esac
-done
-
-chmod 0660 /var/run/docker.sock && chown root:$docker_group /var/run/docker.sock
+# Change permissions to docker.sock to allow user access
+chmod 0660 /var/run/docker.sock && chown root:$DIUID_DOCKERD_GROUP /var/run/docker.sock
 
 PATH=/usr/bin:$PATH dockerd --userland-proxy-path=$(which diuid-docker-proxy) -H unix:///var/run/docker.sock $DIUID_DOCKERD_FLAGS
 


### PR DESCRIPTION
Hi! Thank you for great solution! You rock!

This PR allows users in the `docker` group use the docker.

It fixes this case:
```
# docker run -it --rm -e weberlars/diuid bash
root# useradd -m -G docker penguin && chsh -s /bin/bash penguin && su - penguin
penguin$ docker ps # Got permission denied...
penguin$ stat /var/run/docker.sock
Access: (0600/srw-------)  Uid: (    0/    root)   Gid: (    0/    root)
```

cc @AkihiroSuda 